### PR TITLE
Add daily AI news slack notifier

### DIFF
--- a/.github/workflows/news_to_slack.yml
+++ b/.github/workflows/news_to_slack.yml
@@ -1,0 +1,23 @@
+name: Daily AI News to Slack
+
+on:
+  schedule:
+    - cron: '0 23 * * *'
+  workflow_dispatch:
+
+jobs:
+  post-news:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Post news to Slack
+        env:
+          NEWS_API_KEY: ${{ secrets.NEWS_API_KEY }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: python fetch_ai_news.py

--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# dev
+# Slack への Generative AI ニュース通知
+
+このリポジトリは毎朝8:00(JST)にGenerative AI関連の最新ニュースを10件Slackに送信します。
+
+## セットアップ
+
+1. [NewsAPI](https://newsapi.org/) からAPIキーを取得してください。
+2. SlackワークスペースのIncoming Webhook URLを作成してください。
+3. 次のリポジトリシークレットを設定します:
+   - `NEWS_API_KEY`: NewsAPIのAPIキー
+   - `SLACK_WEBHOOK_URL`: SlackのWebhook URL
+
+## 仕組み
+
+`.github/workflows/news_to_slack.yml` に定義されたGitHub Actionsワークフローが毎日23:00 UTC (日本時間8:00) に実行されます。`fetch_ai_news.py` が「generative AI」を含む最新記事を10件取得し、Webhook経由でSlackへ投稿します。
+
+## ローカル実行
+
+```bash
+pip install -r requirements.txt
+export NEWS_API_KEY=あなたのNewsAPIキー
+export SLACK_WEBHOOK_URL=https://hooks.slack.com/services/...
+python fetch_ai_news.py
+```

--- a/fetch_ai_news.py
+++ b/fetch_ai_news.py
@@ -1,0 +1,60 @@
+import os
+import sys
+from datetime import datetime
+
+import requests
+
+NEWS_API_KEY = os.getenv('NEWS_API_KEY')
+SLACK_WEBHOOK_URL = os.getenv('SLACK_WEBHOOK_URL')
+
+NEWS_API_URL = 'https://newsapi.org/v2/everything'
+
+
+def get_news():
+    params = {
+        'q': 'generative AI',
+        'pageSize': 10,
+        'sortBy': 'publishedAt',
+        'language': 'en',
+        'apiKey': NEWS_API_KEY,
+    }
+    try:
+        response = requests.get(NEWS_API_URL, params=params, timeout=10)
+        response.raise_for_status()
+    except requests.RequestException as e:
+        print(f"Failed to fetch news: {e}", file=sys.stderr)
+        return []
+    data = response.json()
+    return data.get('articles', [])
+
+
+def send_to_slack(articles):
+    if not SLACK_WEBHOOK_URL:
+        print('SLACK_WEBHOOK_URL is not set', file=sys.stderr)
+        return
+    if not articles:
+        print('No articles to send', file=sys.stderr)
+        return
+    text_lines = [f"*Generative AI news for {datetime.utcnow().date()}*\n"]
+    for i, a in enumerate(articles, 1):
+        title = a.get('title', 'No title')
+        url = a.get('url', '')
+        text_lines.append(f"{i}. <{url}|{title}>")
+    payload = {'text': '\n'.join(text_lines)}
+    try:
+        resp = requests.post(SLACK_WEBHOOK_URL, json=payload, timeout=10)
+        resp.raise_for_status()
+    except requests.RequestException as e:
+        print(f"Failed to post to Slack: {e}", file=sys.stderr)
+
+
+def main():
+    if not NEWS_API_KEY:
+        print('NEWS_API_KEY is not set', file=sys.stderr)
+        return
+    articles = get_news()
+    send_to_slack(articles)
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests


### PR DESCRIPTION
## Summary
- READMEを日本語化
- エラーにならないようfetch_ai_news.pyに例外処理を追加

## Testing
- `python -m py_compile fetch_ai_news.py`
- `pip install -r requirements.txt`
- `NEWS_API_KEY=dummy SLACK_WEBHOOK_URL=http://example.com python fetch_ai_news.py` *(fails gracefully due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6841b61a05188322a7cedc79b2e5540f