### PR TITLE
Add ServiceNow MCP server with mock data and demo client

### DIFF
--- a/README_MCP.md
+++ b/README_MCP.md
@@ -1,0 +1,44 @@
+# AI-IVR向け ServiceNow MCP サーバー
+
+市販製品AI-IVRからServiceNowのAPI群を呼び出すためのMCPサーバー実装です。閉域環境でServiceNowへ直接接続できない前提のため、**モックデータでの動作確認**を標準で提供します。
+
+## 対応ツール
+
+| MCPツール名 | 概要 |
+| --- | --- |
+| `contract_check` | 契約番号・契約氏名から契約の存在確認を行う |
+| `get_onu_router_name` | 契約番号からONUルーター名を取得 |
+| `line_test` | 回線試験（モック）を行いランプ点灯状態を取得 |
+| `get_router_shipping_address` | ルーター送付先住所を取得 |
+| `create_case` | ケース起票 |
+
+## モックデータ
+
+`mcp_server/data/mock_data.json` に検証用の契約データを定義しています。ServiceNowに接続できない場合でも、ここにある情報を使ってMCPの呼び出し検証が可能です。
+
+## 実行方法 (モック)
+
+```bash
+pip install -r requirements.txt
+pip install mcp
+python -m mcp_server
+```
+
+MCPクライアントでの簡易確認:
+
+```bash
+python scripts/demo_mcp_client.py
+```
+
+## ServiceNow接続
+
+以下の環境変数を設定するとServiceNow APIを呼び出します。
+
+```bash
+export SERVICENOW_BASE_URL="https://your-instance.service-now.com"
+export SERVICENOW_USERNAME="api_user"
+export SERVICENOW_PASSWORD="api_password"
+python -m mcp_server
+```
+
+※ ServiceNow APIのテーブル名・フィールド名は `u_contract` / `u_case` を前提にしています。環境に合わせて `mcp_server/server.py` 内のパスとフィールド名を変更してください。

--- a/mcp_server/__init__.py
+++ b/mcp_server/__init__.py
@@ -1,0 +1,1 @@
+"""AI-IVR向けServiceNow MCPサーバー実装。"""

--- a/mcp_server/__main__.py
+++ b/mcp_server/__main__.py
@@ -1,0 +1,4 @@
+from mcp_server.server import run
+
+if __name__ == "__main__":
+    run()

--- a/mcp_server/data/mock_data.json
+++ b/mcp_server/data/mock_data.json
@@ -1,0 +1,26 @@
+{
+  "contracts": {
+    "C-10001": {
+      "contract_name": "田中 太郎",
+      "onu_router_name": "ONU-AX1800",
+      "lamp_status": {
+        "power": "on",
+        "optical": "blink",
+        "internet": "off",
+        "alarm": "off"
+      },
+      "shipping_address": "東京都港区芝公園1-1-1"
+    },
+    "C-10002": {
+      "contract_name": "佐藤 花子",
+      "onu_router_name": "ONU-BX2400",
+      "lamp_status": {
+        "power": "on",
+        "optical": "on",
+        "internet": "on",
+        "alarm": "off"
+      },
+      "shipping_address": "大阪府大阪市北区梅田2-2-2"
+    }
+  }
+}

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import requests
+from mcp.server.fastmcp import FastMCP
+
+DATA_PATH = Path(__file__).resolve().parent / "data" / "mock_data.json"
+
+
+@dataclass
+class ContractInfo:
+    contract_name: str
+    onu_router_name: str
+    lamp_status: Dict[str, str]
+    shipping_address: str
+
+
+class MockRepository:
+    def __init__(self, data_path: Path = DATA_PATH) -> None:
+        self._data_path = data_path
+        self._contracts = self._load_contracts()
+
+    def _load_contracts(self) -> Dict[str, ContractInfo]:
+        payload = json.loads(self._data_path.read_text(encoding="utf-8"))
+        contracts: Dict[str, ContractInfo] = {}
+        for contract_id, info in payload.get("contracts", {}).items():
+            contracts[contract_id] = ContractInfo(
+                contract_name=info["contract_name"],
+                onu_router_name=info["onu_router_name"],
+                lamp_status=info["lamp_status"],
+                shipping_address=info["shipping_address"],
+            )
+        return contracts
+
+    def get_contract(self, contract_id: str) -> Optional[ContractInfo]:
+        return self._contracts.get(contract_id)
+
+
+class ServiceNowClient:
+    def __init__(self, base_url: str, username: str, password: str) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._session = requests.Session()
+        self._session.auth = (username, password)
+        self._session.headers.update({"Accept": "application/json"})
+
+    def _get(self, path: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        response = self._session.get(f"{self._base_url}{path}", params=params, timeout=15)
+        response.raise_for_status()
+        return response.json()
+
+    def _post(self, path: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        response = self._session.post(
+            f"{self._base_url}{path}",
+            json=payload,
+            timeout=15,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def find_contract(self, contract_id: str, contract_name: str) -> bool:
+        data = self._get(
+            "/api/now/table/u_contract",
+            params={"sysparm_query": f"number={contract_id}^name={contract_name}"},
+        )
+        return bool(data.get("result"))
+
+    def fetch_router_name(self, contract_id: str) -> Optional[str]:
+        data = self._get(
+            "/api/now/table/u_contract",
+            params={"sysparm_query": f"number={contract_id}", "sysparm_fields": "u_onu_router"},
+        )
+        result = data.get("result")
+        if not result:
+            return None
+        return result[0].get("u_onu_router")
+
+    def fetch_shipping_address(self, contract_id: str) -> Optional[str]:
+        data = self._get(
+            "/api/now/table/u_contract",
+            params={"sysparm_query": f"number={contract_id}", "sysparm_fields": "u_shipping_address"},
+        )
+        result = data.get("result")
+        if not result:
+            return None
+        return result[0].get("u_shipping_address")
+
+    def create_case(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        return self._post("/api/now/table/u_case", payload)
+
+
+class ServiceLayer:
+    def __init__(self, mock_repo: MockRepository, sn_client: Optional[ServiceNowClient]) -> None:
+        self._mock_repo = mock_repo
+        self._sn_client = sn_client
+
+    def contract_exists(self, contract_id: str, contract_name: str) -> bool:
+        if self._sn_client:
+            return self._sn_client.find_contract(contract_id, contract_name)
+        contract = self._mock_repo.get_contract(contract_id)
+        return bool(contract and contract.contract_name == contract_name)
+
+    def get_router_name(self, contract_id: str) -> Optional[str]:
+        if self._sn_client:
+            return self._sn_client.fetch_router_name(contract_id)
+        contract = self._mock_repo.get_contract(contract_id)
+        return contract.onu_router_name if contract else None
+
+    def get_lamp_status(self, contract_id: str) -> Optional[Dict[str, str]]:
+        contract = self._mock_repo.get_contract(contract_id)
+        return contract.lamp_status if contract else None
+
+    def get_shipping_address(self, contract_id: str) -> Optional[str]:
+        if self._sn_client:
+            return self._sn_client.fetch_shipping_address(contract_id)
+        contract = self._mock_repo.get_contract(contract_id)
+        return contract.shipping_address if contract else None
+
+    def create_case(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        if self._sn_client:
+            return self._sn_client.create_case(payload)
+        return {
+            "result": {
+                "case_id": f"MOCK-{datetime.utcnow().strftime('%Y%m%d%H%M%S')}",
+                "status": "created",
+                "payload": payload,
+            }
+        }
+
+
+def build_service_layer() -> ServiceLayer:
+    mock_repo = MockRepository()
+    base_url = os.getenv("SERVICENOW_BASE_URL")
+    username = os.getenv("SERVICENOW_USERNAME")
+    password = os.getenv("SERVICENOW_PASSWORD")
+    if base_url and username and password:
+        return ServiceLayer(mock_repo, ServiceNowClient(base_url, username, password))
+    return ServiceLayer(mock_repo, None)
+
+
+mcp = FastMCP("ai-ivr-servicenow")
+service = build_service_layer()
+
+
+@mcp.tool()
+def contract_check(contract_id: str, contract_name: str) -> Dict[str, Any]:
+    """契約番号・契約氏名から契約存在確認を行う。"""
+    exists = service.contract_exists(contract_id, contract_name)
+    return {"contract_id": contract_id, "contract_name": contract_name, "exists": exists}
+
+
+@mcp.tool()
+def get_onu_router_name(contract_id: str) -> Dict[str, Any]:
+    """契約番号からONUルーター名を取得する。"""
+    router_name = service.get_router_name(contract_id)
+    return {"contract_id": contract_id, "onu_router_name": router_name}
+
+
+@mcp.tool()
+def line_test(contract_id: str) -> Dict[str, Any]:
+    """回線試験を実行し、ルーターのランプ状態を返す。"""
+    lamp_status = service.get_lamp_status(contract_id)
+    return {"contract_id": contract_id, "lamp_status": lamp_status}
+
+
+@mcp.tool()
+def get_router_shipping_address(contract_id: str) -> Dict[str, Any]:
+    """契約番号からルーター送付先住所を取得する。"""
+    address = service.get_shipping_address(contract_id)
+    return {"contract_id": contract_id, "shipping_address": address}
+
+
+@mcp.tool()
+def create_case(
+    contract_name: str,
+    contract_id: str,
+    onu_router_name: str,
+    lamp_status: Dict[str, str],
+    shipping_address: str,
+    shipping_date: str,
+) -> Dict[str, Any]:
+    """ケース起票を行う。"""
+    payload = {
+        "contract_name": contract_name,
+        "contract_id": contract_id,
+        "onu_router_name": onu_router_name,
+        "lamp_status": lamp_status,
+        "shipping_address": shipping_address,
+        "shipping_date": shipping_date,
+    }
+    return service.create_case(payload)
+
+
+def run() -> None:
+    mcp.run()
+
+
+if __name__ == "__main__":
+    run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests
+mcp

--- a/scripts/demo_mcp_client.py
+++ b/scripts/demo_mcp_client.py
@@ -1,0 +1,55 @@
+import asyncio
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+
+async def main() -> None:
+    server_params = StdioServerParameters(command="python", args=["-m", "mcp_server"])
+    async with stdio_client(server_params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+
+            print("contract_check:")
+            result = await session.call_tool(
+                "contract_check",
+                {"contract_id": "C-10001", "contract_name": "田中 太郎"},
+            )
+            print(result)
+
+            print("get_onu_router_name:")
+            result = await session.call_tool("get_onu_router_name", {"contract_id": "C-10001"})
+            print(result)
+
+            print("line_test:")
+            result = await session.call_tool("line_test", {"contract_id": "C-10001"})
+            print(result)
+
+            print("get_router_shipping_address:")
+            result = await session.call_tool(
+                "get_router_shipping_address", {"contract_id": "C-10001"}
+            )
+            print(result)
+
+            print("create_case:")
+            result = await session.call_tool(
+                "create_case",
+                {
+                    "contract_name": "田中 太郎",
+                    "contract_id": "C-10001",
+                    "onu_router_name": "ONU-AX1800",
+                    "lamp_status": {
+                        "power": "on",
+                        "optical": "blink",
+                        "internet": "off",
+                        "alarm": "off",
+                    },
+                    "shipping_address": "東京都港区芝公園1-1-1",
+                    "shipping_date": "2025-01-31",
+                },
+            )
+            print(result)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
### Motivation
- Provide an MCP server so an AI-IVR can call ServiceNow APIs while supporting closed-network environments where ServiceNow access is not possible. 
- Allow easy local verification of MCP tool behavior by using a mock data fallback when external API access is unavailable.

### Description
- Add `mcp_server/server.py` which implements `ServiceNowClient`, `MockRepository`, `ServiceLayer`, and MCP tool handlers `contract_check`, `get_onu_router_name`, `line_test`, `get_router_shipping_address`, and `create_case`.
- Add mock dataset `mcp_server/data/mock_data.json` with sample contracts used by the mock fallback implementation.
- Add `scripts/demo_mcp_client.py` which starts the MCP server via stdio and exercises all tools for quick local verification.
- Add `README_MCP.md`, package entrypoint `mcp_server/__main__.py`, `mcp_server/__init__.py`, and update `requirements.txt` to include `mcp`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69867211e8248322858c1cb9b0bcb8cb)