### PR TITLE
Add Foundry MCP server scaffold with mock data and local test (AI‑IVR → ServiceNow)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,7 @@ export NEWS_API_KEY=あなたのNewsAPIキー
 export SLACK_WEBHOOK_URL=https://hooks.slack.com/services/...
 python fetch_ai_news.py
 ```
+
+## MCP サーバー (AI-IVR ↔ ServiceNow)
+
+Foundry で MCP サーバーを構築し、閉域環境で検証するための手順と参考実装を `mcp_server/README.md` にまとめました。

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -1,0 +1,112 @@
+# Foundry 用 MCP サーバー (AI-IVR ↔ ServiceNow)
+
+このフォルダーは、市販製品 AI-IVR から ServiceNow API 相当の操作を呼び出す MCP サーバー構成の参考実装と、Microsoft の公式手順に沿った構築・検証フローをまとめたものです。外部接続が不可の環境でも MCP の動作確認ができるよう、**ローカルのダミーデータで検証できる構成**を含めています。
+
+## Microsoft 公式手順に沿った構築フロー
+
+> **公式手順**: [モデル コンテキスト プロトコル (MCP) サーバーをビルドして登録する](https://learn.microsoft.com/ja-jp/azure/ai-foundry/mcp/build-your-own-mcp-server?view=foundry)
+
+以下は、公式手順の流れに沿って整理した作業ステップです。各ステップの末尾に、**公式手順に対応する箇所**と、必要な **チューニング内容**を明記しています。
+
+### 1. 前提条件の準備
+
+- Foundry Agent Service が有効なプロジェクト
+- Azure サブスクリプションと権限 (通常はリソースグループの共同作成者)
+- Python 3.11+
+- Azure Functions Core Tools v4
+- Azure Developer CLI (azd)
+- (任意) Azure API Center
+
+> **公式手順に対応**: 「前提条件」節
+
+### 2. MCP サーバー用テンプレートの取得
+
+```bash
+azd init --template remote-mcp-functions-python -e mcpserver-python
+```
+
+> **公式手順に対応**: 「Azure Functions を使用して MCP サーバーを構築する」節の `azd init` ステップ
+
+### 3. MCP ツール定義の実装 (チューニング)
+
+公式テンプレート生成後、MCP が公開するツール定義を以下の 5 種類に置き換えます。
+
+| ツール名 | 入力 | 出力 | 説明 |
+| --- | --- | --- | --- |
+| `contract_check` | `contract_number`, `contract_name` | `bool` | 契約情報の存在確認 |
+| `get_onu_router_name` | `contract_number` | `str` | ONU ルーター名取得 |
+| `run_line_test` | `contract_number` | `Dict[str, str]` | 回線試験 (ランプ状態) |
+| `get_router_shipping_address` | `contract_number` | `str` | ルーター送付先住所 |
+| `create_case` | `customer_name`, `contract_number`, `router_name`, `router_lamp_status`, `shipping_address`, `shipping_date` | `Dict[str, str]` | ケース起票 |
+
+> **公式手順に対応**: 「MCP サーバー関数をカスタマイズして特定の API とサービスを公開します」
+> 
+> **チューニング内容**: AI-IVR のシナリオに合わせてツール定義を変更 (上記 5 ツール)
+
+テンプレート内の MCP 関数定義部分を、`mcp_server/mcp_server.py` にある関数定義に合わせる形で更新してください。
+
+### 4. ローカルで MCP を起動して確認
+
+```bash
+func start
+```
+
+> **公式手順に対応**: 「Azure Functions Core Tools を使用して、MCP サーバーをローカルでテストします」
+
+### 5. Azure へデプロイ
+
+```bash
+azd up
+```
+
+> **公式手順に対応**: 「Azure Developer CLI を使用して MCP サーバーを Azure にデプロイします」
+
+### 6. (任意) API Center 登録 & Foundry から接続
+
+必要に応じて Azure API Center に登録し、Foundry から MCP サーバーを接続します。
+
+> **公式手順に対応**: 「Azure API Center を使用してプライベート組織ツールカタログに登録」〜「Foundry から MCP サーバーを接続」
+
+---
+
+## チューニングした MCP サーバー実装 (ローカル検証用)
+
+外部接続が不可の閉域環境でも MCP の API 呼び出しを検証できるように、ローカルで動作する MCP サーバーを用意しています。`mcp_server.py` は **MCP over stdio** で実行でき、`test_mcp_local.py` で一連の API 呼び出しを検証できます。
+
+### 1. 依存関係の準備
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install mcp
+```
+
+### 2. MCP サーバーの起動
+
+```bash
+python mcp_server.py
+```
+
+### 3. MCP ツール呼び出し検証
+
+別ターミナルで以下を実行します。
+
+```bash
+python test_mcp_local.py
+```
+
+> **チューニング内容**: `mock_data.py` のダミーデータを使って外部 API 呼び出しを模擬し、閉域環境でも MCP 検証ができるようにしました。
+
+---
+
+## ServiceNow への切り替えについて
+
+閉域接続のみの環境では ServiceNow への外部通信ができないため、本フォルダーのローカル検証はダミーデータで実施します。運用環境で ServiceNow に切り替える場合は、`mcp_server.py` の各ツール実装で ServiceNow REST API を呼び出す実装に置き換えます。MCP のツール定義はそのまま使えるため、**テストと本番で MCP のインターフェースを共通化**できます。
+
+---
+
+## ファイル構成
+
+- `mcp_server.py`: MCP ツール定義 (AI-IVR 用 5 API)
+- `mock_data.py`: 閉域検証用のダミーデータ
+- `test_mcp_local.py`: MCP のローカル検証用スクリプト

--- a/mcp_server/mcp_server.py
+++ b/mcp_server/mcp_server.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict
+
+from mcp.server.fastmcp import FastMCP
+
+from mock_data import CASES, CONTRACTS, ROUTER_LAMP_STATUS, ROUTER_SHIPPING_ADDRESSES, next_case_id
+
+mcp = FastMCP("ai-ivr-servicenow")
+
+
+@mcp.tool()
+def contract_check(contract_number: str, contract_name: str) -> bool:
+    """契約番号と契約氏名が一致するかを確認します。"""
+    record = CONTRACTS.get(contract_number)
+    return bool(record and record["contract_name"] == contract_name)
+
+
+@mcp.tool()
+def get_onu_router_name(contract_number: str) -> str:
+    """契約番号から ONU ルーター名を返します。"""
+    record = CONTRACTS.get(contract_number)
+    if not record:
+        return ""
+    return record["router_name"]
+
+
+@mcp.tool()
+def run_line_test(contract_number: str) -> Dict[str, str]:
+    """回線試験を実行し、ルーターのランプ点灯状態を返します。"""
+    record = CONTRACTS.get(contract_number)
+    if not record:
+        return {}
+    router_name = record["router_name"]
+    return ROUTER_LAMP_STATUS.get(router_name, {})
+
+
+@mcp.tool()
+def get_router_shipping_address(contract_number: str) -> str:
+    """契約番号からルーター送付先住所を返します。"""
+    return ROUTER_SHIPPING_ADDRESSES.get(contract_number, "")
+
+
+@mcp.tool()
+def create_case(
+    customer_name: str,
+    contract_number: str,
+    router_name: str,
+    router_lamp_status: Dict[str, str],
+    shipping_address: str,
+    shipping_date: str,
+) -> Dict[str, str]:
+    """ケース起票を行い、ケース番号を返します。"""
+    case_id = next_case_id()
+    CASES.append(
+        {
+            "case_id": case_id,
+            "customer_name": customer_name,
+            "contract_number": contract_number,
+            "router_name": router_name,
+            "router_lamp_status": str(router_lamp_status),
+            "shipping_address": shipping_address,
+            "shipping_date": shipping_date,
+            "created_at": datetime.utcnow().isoformat(timespec="seconds"),
+        }
+    )
+    return {"case_id": case_id}
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/mcp_server/mock_data.py
+++ b/mcp_server/mock_data.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import Dict, List
+
+CONTRACTS: Dict[str, Dict[str, str]] = {
+    "CN-10001": {"contract_name": "佐藤太郎", "router_name": "ONU-AX12"},
+    "CN-10002": {"contract_name": "鈴木花子", "router_name": "ONU-BX200"},
+    "CN-10003": {"contract_name": "田中一郎", "router_name": "ONU-CX90"},
+}
+
+ROUTER_LAMP_STATUS: Dict[str, Dict[str, str]] = {
+    "ONU-AX12": {
+        "power": "on",
+        "optical": "blink",
+        "alarm": "off",
+        "lan": "on",
+    },
+    "ONU-BX200": {
+        "power": "on",
+        "optical": "on",
+        "alarm": "off",
+        "lan": "off",
+    },
+    "ONU-CX90": {
+        "power": "off",
+        "optical": "off",
+        "alarm": "on",
+        "lan": "off",
+    },
+}
+
+ROUTER_SHIPPING_ADDRESSES: Dict[str, str] = {
+    "CN-10001": "東京都千代田区1-2-3",
+    "CN-10002": "大阪府大阪市北区4-5-6",
+    "CN-10003": "福岡県福岡市中央区7-8-9",
+}
+
+CASES: List[Dict[str, str]] = []
+
+
+def next_case_id() -> str:
+    sequence = len(CASES) + 1
+    return f"CASE-{date.today().strftime('%Y%m%d')}-{sequence:03d}"

--- a/mcp_server/test_mcp_local.py
+++ b/mcp_server/test_mcp_local.py
@@ -1,0 +1,46 @@
+import asyncio
+
+from mcp.client import ClientSession
+from mcp.client.stdio import stdio_client
+
+
+async def main() -> None:
+    async with stdio_client("python mcp_server.py") as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            contract_ok = await session.call_tool(
+                "contract_check",
+                {"contract_number": "CN-10001", "contract_name": "佐藤太郎"},
+            )
+            router_name = await session.call_tool(
+                "get_onu_router_name",
+                {"contract_number": "CN-10001"},
+            )
+            lamp_status = await session.call_tool(
+                "run_line_test",
+                {"contract_number": "CN-10001"},
+            )
+            address = await session.call_tool(
+                "get_router_shipping_address",
+                {"contract_number": "CN-10001"},
+            )
+            case_result = await session.call_tool(
+                "create_case",
+                {
+                    "customer_name": "佐藤太郎",
+                    "contract_number": "CN-10001",
+                    "router_name": router_name.content,
+                    "router_lamp_status": lamp_status.content,
+                    "shipping_address": address.content,
+                    "shipping_date": "2025-04-01",
+                },
+            )
+            print("contract_check:", contract_ok.content)
+            print("router_name:", router_name.content)
+            print("lamp_status:", lamp_status.content)
+            print("shipping_address:", address.content)
+            print("case_result:", case_result.content)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
### Motivation

- Provide an MCP server implementation and guide that follows Microsoft Foundry's official MCP build/register flow for an AI‑IVR → ServiceNow integration.
- Support the operator's closed (no internet) environment by enabling offline/local verification of MCP behavior using in‑memory mock data.
- Expose the specific AI‑IVR APIs (contract check, ONU router name, line test, shipping address, case creation) as MCP tools so the interface can be swapped to ServiceNow REST calls in production.

### Description

- Added a new `mcp_server/` folder including `mcp_server.py`, `mock_data.py`, `test_mcp_local.py`, and `mcp_server/README.md` documenting how the changes map to the Microsoft guidance and what was tuned. 
- Implemented five MCP tools in `mcp_server.py` using `FastMCP`: `contract_check`, `get_onu_router_name`, `run_line_test`, `get_router_shipping_address`, and `create_case` (which appends to an in‑memory `CASES`).
- Created `mock_data.py` with sample `CONTRACTS`, `ROUTER_LAMP_STATUS`, `ROUTER_SHIPPING_ADDRESSES`, `CASES`, and a `next_case_id()` generator to support offline testing.
- Added `test_mcp_local.py` which uses `mcp.client.stdio.stdio_client` and `ClientSession` to exercise the 5 tools over stdio for local verification, and linked the new MCP guide from the repository root `README.md`.

### Testing

- No automated tests were executed for this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69888b7068c083228d6be565bc27d4e3)